### PR TITLE
Tweak Proxy `responseTransformer`

### DIFF
--- a/lib/proxy.ts
+++ b/lib/proxy.ts
@@ -43,7 +43,7 @@ export interface ProxiedUpstreamRequest {
 export interface ProxiedRouteRule {
   incomingRequest: ProxiedIncomingRequest;
   upstreamRequest?: ProxiedUpstreamRequest;
-  responseTransformer?: (response: APIGatewayProxyResult) => HttpResponse;
+  responseTransformer?: (response: APIGatewayProxyResult, event: APIGatewayEvent) => HttpResponse;
   scope?: string;
 }
 
@@ -191,7 +191,7 @@ export const handleProxiedRequest = async (
     .then(({ statusCode, data }) => response(statusCode, data))
     .then(response =>
       routeRule.responseTransformer
-        ? routeRule.responseTransformer(response)
+        ? routeRule.responseTransformer(response, event)
         : response
     )
     .catch(logAndReturnErrorResponse);

--- a/lib/proxy.ts
+++ b/lib/proxy.ts
@@ -1,4 +1,4 @@
-import { APIGatewayEvent, APIGatewayProxyResult, Context } from 'aws-lambda';
+import { APIGatewayEvent, Context } from 'aws-lambda';
 import DefaultAxios, { AxiosInstance, Method, AxiosResponse, AxiosError, AxiosRequestConfig } from 'axios';
 import fromEntries from 'object.fromentries';
 import { pathToRegexp } from 'path-to-regexp';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifeway/serverless-utilities",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifeway/serverless-utilities",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "AWS Serverless utilities created and used by Lifeway.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/test/proxy.spec.ts
+++ b/test/proxy.spec.ts
@@ -1,7 +1,7 @@
 import axios, { AxiosRequestConfig, Method } from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 import { random } from 'faker';
-import { APIGatewayEvent, APIGatewayProxyResult } from 'aws-lambda';
+import { APIGatewayEvent } from 'aws-lambda';
 import {
   findMatchingRoutingRule,
   replacePathParameters,

--- a/test/proxy.spec.ts
+++ b/test/proxy.spec.ts
@@ -414,11 +414,9 @@ describe('handleProxiedRequest', () => {
       upstreamRequest: {
         url: upstreamUrl,
       },
-      responseTransformer: (response: APIGatewayProxyResult, evt: APIGatewayEvent) => ({
+      responseTransformer: (response: HttpResponse, evt: APIGatewayEvent) => ({
         ...response,
-        body: JSON.stringify(
-          JSON.parse(response.body)?.filter((item: Item) => item.id === evt.pathParameters?.id)
-        )
+        data: response.data?.filter((item: Item) => item.id === evt.pathParameters?.id)
       }),
     };
     return handleProxiedRequest(event as APIGatewayEvent, routeRule)


### PR DESCRIPTION
Pass the API Gateway event to the `responseTransformer` to allow access to the path parameters & such. Also, run the `responseTransformer` **before** the upstream response is mapped to an api gateway response. This way the response body does not have to be parsed & re-stringified.