### PR TITLE
Update EventRouter logging

### DIFF
--- a/lib/eventRouter.ts
+++ b/lib/eventRouter.ts
@@ -104,7 +104,7 @@ const processInOrder = async (events: any, routerRules: any) => {
     } else {
       const promise = Promise.all(handlers.map((handler: any) => handler(event).catch(handleError)));
       const res = await promise;
-      logger.debug(logPrefix, `Event handlers processed event ${event.id} with result: ${res}`);
+      logger.debug(logPrefix, `Event handlers processed event ${event.id} with result:`, res);
       results.push(res);
     }
   }
@@ -131,12 +131,13 @@ const getHandlersForLifewayEvent = (routerRules: any, event: any) => {
 
 const handleResults = (results: any, events: any) => {
   if (results.length === 0) {
-    const msg = `${logPrefix} No handlers triggered for event types: ${JSON.stringify(events.map((event: any) => event.eventType))}`;
+    const msg = `${logPrefix} No handlers triggered for events: ${JSON.stringify(events.map((event: any) => event.eventType))}`;
     logger.info(msg);
     return msg;
   }
+  logger.debug(JSON.stringify(results, null, 2));
 
-  const msg = `${logPrefix} Completed processing ${events.length} event(s): ${results}`;
+  const msg = `${logPrefix} Completed processing ${events.length} event(s): ${JSON.stringify(results.flat())}`;
   logger.info(msg);
   return msg;
 };

--- a/lib/eventRouter.ts
+++ b/lib/eventRouter.ts
@@ -104,7 +104,7 @@ const processInOrder = async (events: any, routerRules: any) => {
     } else {
       const promise = Promise.all(handlers.map((handler: any) => handler(event).catch(handleError)));
       const res = await promise;
-      logger.debug(logPrefix, `Event handlers processed event ${event.id} with result: [ ${res.join(' | ')} ]`);
+      logger.debug(logPrefix, `Event handlers processed event ${event.id} with result: ${res}`);
       results.push(res);
     }
   }
@@ -131,12 +131,12 @@ const getHandlersForLifewayEvent = (routerRules: any, event: any) => {
 
 const handleResults = (results: any, events: any) => {
   if (results.length === 0) {
-    const msg = `${logPrefix} No handlers triggered for events [ ${events.map((event: any) => event.eventType).join(' | ')} ]`;
+    const msg = `${logPrefix} No handlers triggered for event types: ${JSON.stringify(events.map((event: any) => event.eventType))}`;
     logger.info(msg);
     return msg;
   }
 
-  const msg = `${logPrefix} Completed processing ${events.length} event(s): [ ${results.join(' | ')} ]`;
+  const msg = `${logPrefix} Completed processing ${events.length} event(s): ${results}`;
   logger.info(msg);
   return msg;
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifeway/serverless-utilities",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "AWS Serverless utilities created and used by Lifeway.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/test/eventRouter.spec.ts
+++ b/test/eventRouter.spec.ts
@@ -54,7 +54,7 @@ describe('eventRouter', () => {
     return EventRouter.route(exampleRules, { source: 'SNS', gaurenteeOrder: true })(generateSNSEvent('TateTookLunch', { foo: 'bar'}))
       .then(res => {
         expect(tateHandler).toHaveBeenCalledTimes(1);
-        expect(res).toContain('Completed processing 1 event(s): [ Yay ]');
+        expect(res).toContain('Completed processing 1 event(s): ["Yay"]');
       });
   });
 
@@ -73,7 +73,7 @@ describe('eventRouter', () => {
     return EventRouter.route(exampleRules, { source: 'SNS', gaurenteeOrder: false })(generateSNSEvent('CharlieTookLunch', { foo: 'bar'}))
       .then(res => {
         expect(charlieHandler).toHaveBeenCalledTimes(1);
-        expect(res).toContain('Completed processing 1 event(s): [ Yay ]');
+        expect(res).toContain('Completed processing 1 event(s): ["Yay"]');
       });
   });
 
@@ -83,7 +83,7 @@ describe('eventRouter', () => {
     return EventRouter.route(exampleRules, { source: 'SNS', gaurenteeOrder: false })(generateSNSEvent('TeamLunchHappened', { foo: 'bar'}))
       .then(res => {
         expect(charlieHandler).toHaveBeenCalledTimes(1);
-        expect(res).toContain('Completed processing 1 event(s): [ Yay,Yay ]');
+        expect(res).toContain('Completed processing 1 event(s): ["Yay","Yay"]');
       });
   });
 
@@ -92,7 +92,7 @@ describe('eventRouter', () => {
     return EventRouter.route(exampleRules, { source: 'kinesis', gaurenteeOrder: true })(generateKinesisEvent([{eventType: 'TateTookLunch', payload: { foo: 'bar'}}]))
       .then(res => {
         expect(tateHandler).toHaveBeenCalledTimes(1);
-        expect(res).toContain('Completed processing 1 event(s): [ Yay ]');
+        expect(res).toContain(`Completed processing 1 event(s): ["Yay"]`);
       });
   });
 
@@ -104,7 +104,7 @@ describe('eventRouter', () => {
     ]))
       .then(res => {
         expect(tateHandler).toHaveBeenCalledTimes(1);
-        expect(res).toContain('Completed processing 2 event(s): [ No handlers defined for eventType TateUpdatedSlackStatus | Yay ]');
+        expect(res).toContain('Completed processing 2 event(s): ["No handlers defined for eventType TateUpdatedSlackStatus","Yay"]');
       });
   });
 
@@ -123,7 +123,7 @@ describe('eventRouter', () => {
       .then(res => {
         expect(tateHandler).toHaveBeenCalledTimes(2);
         expect(charlieHandler).toHaveBeenCalledTimes(2);
-        expect(res).toContain('Completed processing 3 event(s): [ Yay | Yay | Yay,Yay ]');
+        expect(res).toContain('Completed processing 3 event(s): ["Yay","Yay","Yay","Yay"]');
       });
   });
 
@@ -134,7 +134,7 @@ describe('eventRouter', () => {
       .then(res => {
         expect(charlieHandler).not.toHaveBeenCalled();
         expect(tateHandler).not.toHaveBeenCalled();
-        expect(res).toContain('No handlers triggered for events [ NoSuchEvent ]');
+        expect(res).toContain('No handlers triggered for events: ["NoSuchEvent"]');
       });
   });
 


### PR DESCRIPTION
Update the logging to avoid `Object object` in cloudwatch

example:
`<INFO> [EVENT ROUTER] Completed processing 1 event(s): [ [object Object] ]`